### PR TITLE
Load fresh data based on active page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -92,6 +92,7 @@ class _App extends React.Component<AppPageProps, AppState> {
           ref={this.dataLayer}
           provideNewItems={this.newItemsProvided}
           updateIsLoadingStatus={isLoading => this.setState({ isLoading })}
+          loadFreshSource={this.state.activeList}
         />
 
         <Header

--- a/client/src/DataLayer.tsx
+++ b/client/src/DataLayer.tsx
@@ -21,6 +21,7 @@ export interface DataList {
 interface DataLayerProps {
   provideNewItems(items: HnItem[], listType: HnListSource): void;
   updateIsLoadingStatus(newStatus: boolean): void;
+  loadFreshSource: HnListSource;
 }
 
 export class DataLayer extends React.Component<DataLayerProps, DataLayerState> {
@@ -202,8 +203,9 @@ export class DataLayer extends React.Component<DataLayerProps, DataLayerState> {
 
     if (allItems === undefined || allLists === undefined) {
       if (!this.state.isLoadingFresh) {
-        this.loadData(HnListSource.Front);
+        console.log("local storage is empty, loading fresh data based on active page", this.props.loadFreshSource);
         this.setState({ isLoadingFresh: true });
+        this.loadData(this.props.loadFreshSource);
       }
       return;
     }


### PR DESCRIPTION
#### Description
The changes in this pull request are needed to allow the initial load (fresh load) to be influenced by the active page. A property, `loadFreshSource`, has been added to `DataLayer` that allows `_App` to specify which `HnListSource` should be used for the fresh load. Since the fresh load is only performed under specific circumstances, this property is effectively ignored in most situations.

#### Notes
I have no idea if there are side effects or unintended consequences to this change. This change fixes the issue I see on a daily basis: accessing /day in a private session causes my initial page load to be empty. My default bookmark launches /day, but the fresh load previously assumed I would start on the default page.