### PR TITLE
Truncate user name to prevent overflow

### DIFF
--- a/app/components/HnComment.tsx
+++ b/app/components/HnComment.tsx
@@ -169,6 +169,7 @@ export class HnComment extends React.Component<HnCommentProps> {
                 <span
                   className={cn({
                     "text-orange-700 font-bold": isCommentByStoryAuthor,
+                    truncate: true,
                   })}
                 >
                   {comment.by}


### PR DESCRIPTION
Problem resolved by truncating the user name if needed.

<img width="410" alt="image" src="https://github.com/user-attachments/assets/a153a3f2-df29-4fd5-b81f-adb3f0ad52bb">
