### PR TITLE
Allow collapse on story text if present

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -47,6 +47,10 @@ module.exports = {
           typescript: {},
         },
       },
+      rules: {
+        "jsx-a11y/click-events-have-key-events": "off",
+        "jsx-a11y/no-static-element-interactions": "off",
+      },
     },
 
     // Typescript

--- a/app/components/HnStoryPage.tsx
+++ b/app/components/HnStoryPage.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useEffect, useState } from "react";
 
-import { getDomain, isNavigator, timeSince } from "@/utils";
+import { cn, getDomain, isNavigator, timeSince } from "@/utils";
 import { isValidComment } from "./HnComment";
 import { HnCommentList } from "./HnCommentList";
 
@@ -109,6 +109,8 @@ export const HnStoryPage: React.FC<HnStoryPageProps> = ({
     }
   }, [idToScrollTo]);
 
+  const [isTextCollapsed, setIsTextCollapsed] = useState(false);
+
   if (!storyData) {
     return null;
   }
@@ -130,36 +132,52 @@ export const HnStoryPage: React.FC<HnStoryPageProps> = ({
       >
         {storyLinkEl}
       </h2>
-      <h4 className="mb-2">
-        <span>{storyData.by}</span>
-        <span>{" | "}</span>
-        <span>
-          {storyData.score}
-          {" points"}
-        </span>
-        <span>{" | "}</span>
-        <span>{timeSince(storyData.time)} ago</span>
-        <span>{" | "}</span>
-        <span>{getDomain(storyData.url)}</span>
-        {isNavigator && "share" in navigator && (
-          <>
-            <span>{" | "}</span>
-            <button
-              onClick={handleShareClick}
-              className="hover:text-orange-500"
-            >
-              <ArrowUpRightFromSquare size={16} />
-            </button>
-          </>
-        )}
-      </h4>
 
-      {storyData.text !== undefined && (
-        <p
-          className="user-text break-words "
-          dangerouslySetInnerHTML={{ __html: textToRender }}
-        />
-      )}
+      <div
+        className={cn(
+          { "border-l-2 border-orange-500 px-2": storyData.text },
+          {
+            collapsed: isTextCollapsed,
+          }
+        )}
+        onClick={() => {
+          if (!storyData.text) {
+            return;
+          }
+          setIsTextCollapsed(!isTextCollapsed);
+        }}
+      >
+        <h4 className="mb-2">
+          <span>{storyData.by}</span>
+          <span>{" | "}</span>
+          <span>
+            {storyData.score}
+            {" points"}
+          </span>
+          <span>{" | "}</span>
+          <span>{timeSince(storyData.time)} ago</span>
+          <span>{" | "}</span>
+          <span>{getDomain(storyData.url)}</span>
+          {isNavigator && "share" in navigator && (
+            <>
+              <span>{" | "}</span>
+              <button
+                onClick={handleShareClick}
+                className="hover:text-orange-500"
+              >
+                <ArrowUpRightFromSquare size={16} />
+              </button>
+            </>
+          )}
+        </h4>
+
+        {storyData.text !== undefined && !isTextCollapsed && (
+          <p
+            className="user-text break-words "
+            dangerouslySetInnerHTML={{ __html: textToRender }}
+          />
+        )}
+      </div>
 
       <div className="user-text">
         <StoryContext.Provider value={storyData}>


### PR DESCRIPTION
Also revise ESLint rules

The side bar and click event will only appear if the story has text.

## Original
<img width="405" alt="image" src="https://github.com/user-attachments/assets/a522f9d5-5e1a-4b95-967d-580da8230b58">

## New

<img width="407" alt="image" src="https://github.com/user-attachments/assets/6c45bd9f-2b2f-4d70-9d66-292e61a031df">

