### PR TITLE
Fix/sticky and assorted

### DIFF
--- a/src/features/comments/HnComment.tsx
+++ b/src/features/comments/HnComment.tsx
@@ -143,8 +143,8 @@ export function HnComment(props: HnCommentProps) {
         .reduce((acc, val) => acc - val, 0);
     }
 
-    const stickyTop = 32 + depthMatchInAuthorChain * 8;
-    const stickyHeight = Math.max(48 - depthMatchInAuthorChain * 8, 16);
+    const stickyTop = 40 + depthMatchInAuthorChain * 8;
+    const stickyHeight = Math.max(24 - depthMatchInAuthorChain * 8, 16);
 
     return {
       shouldShowBar,

--- a/src/features/storyList/ServerStoryPage.tsx
+++ b/src/features/storyList/ServerStoryPage.tsx
@@ -41,7 +41,8 @@ export function ServerStoryPage(props: { page: TopStoriesType }) {
   );
 
   createEffect(() => {
-    const d = data();
+    const d = data.latest;
+
     const p = props.page;
     if (d?.source === "server" && d?.data.type === "fullData") {
       console.log("*** persisting story list for server data", p, d);
@@ -61,9 +62,9 @@ export function ServerStoryPage(props: { page: TopStoriesType }) {
     }
 
     const summaries =
-      data()?.data.type === "summaryOnly"
-        ? data()?.data.data
-        : mapStoriesToSummaries(data()?.data.data ?? []);
+      data.latest?.data.type === "summaryOnly"
+        ? data.latest?.data.data
+        : mapStoriesToSummaries(data.latest?.data.data ?? []);
 
     if (summaries === undefined) {
       return;


### PR DESCRIPTION
This pull request includes small adjustments to UI layout calculations and data access patterns to improve consistency and maintainability.

UI layout adjustments:

* Updated the calculation of `stickyTop` and `stickyHeight` in the `HnComment` component to adjust spacing and sizing for sticky comment bars. (`src/features/comments/HnComment.tsx`, [src/features/comments/HnComment.tsxL146-R147](diffhunk://#diff-8c9a452a4e875fd24010da5979d8c22541dab3b5eb0c83a3fe0d3fdbb9ac18fdL146-R147))

Data access pattern improvements:

* Changed references from `data()` to `data.latest` in the `ServerStoryPage` component to consistently access the latest data, improving clarity and correctness in data handling. (`src/features/storyList/ServerStoryPage.tsx`, [[1]](diffhunk://#diff-5d3d718938037e207f932a793a33bfdf83ee3d0705149ce4126f09c4f584aea8L44-R45) [[2]](diffhunk://#diff-5d3d718938037e207f932a793a33bfdf83ee3d0705149ce4126f09c4f584aea8L64-R67)