### PR TITLE
Ensure share buttons always visible if hover not possible

### DIFF
--- a/src/features/comments/HnComment.tsx
+++ b/src/features/comments/HnComment.tsx
@@ -200,12 +200,12 @@ export function HnComment(props: HnCommentProps) {
             <Show when={isOpen()}>
               <span class="text-slate-300 select-none">|</span>
               <span>{timeSince(props.comment.time)}</span>
-              <span class="pointer-events-none text-slate-300 opacity-0 transition-opacity group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 select-none">
+              <span class="pointer-events-none text-slate-300 opacity-0 transition-opacity select-none group-hover:opacity-100 [@media(hover:none)]:opacity-100">
                 |
               </span>
               <button
                 onClick={handleShareClick}
-                class="pointer-events-none text-slate-400 opacity-0 transition-opacity group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 hover:text-orange-500 focus-visible:pointer-events-auto focus-visible:opacity-100"
+                class="text-slate-400 opacity-0 transition-opacity group-hover:opacity-100 hover:text-orange-500 [@media(hover:none)]:opacity-100"
                 aria-label="Share"
               >
                 <ArrowUpRightFromSquare width={16} />

--- a/src/features/comments/HnStoryContentCard.tsx
+++ b/src/features/comments/HnStoryContentCard.tsx
@@ -86,7 +86,7 @@ export const HnStoryContentCard = (props: HnStoryContentCardProps) => {
         "--flash-color": flashColor(),
         "padding-left": "16px",
       }}
-      >
+    >
       <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-[16px] text-slate-700">
         <span class="font-medium">{author()}</span>
         <span class="text-slate-300 select-none" aria-hidden="true">
@@ -96,7 +96,7 @@ export const HnStoryContentCard = (props: HnStoryContentCardProps) => {
         <Show when={hasText() && isTextOpen()}>
           <button
             onClick={handleShareClick}
-            class="pointer-events-none ml-auto text-slate-400 opacity-0 transition-opacity group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 hover:text-orange-500 focus-visible:pointer-events-auto focus-visible:opacity-100"
+            class="text-slate-400 opacity-0 transition-opacity group-hover:opacity-100 hover:text-orange-500 [@media(hover:none)]:opacity-100"
             aria-label="Share"
           >
             <ArrowUpRightFromSquare width={16} />


### PR DESCRIPTION
This pull request updates the visibility and interaction behavior of the "Share" button and its adjacent separator in comment and story content components. The changes simplify the CSS classes to improve accessibility on devices that do not support hover, ensuring the "Share" button is always visible on touch devices while maintaining hover-based visibility on desktop.

**UI/UX Improvements:**

* Simplified the CSS classes for the "Share" button and separator in `HnComment.tsx` and `HnStoryContentCard.tsx` to remove focus-based and pointer event logic, and added a media query to make the button visible on devices without hover support. [[1]](diffhunk://#diff-8c9a452a4e875fd24010da5979d8c22541dab3b5eb0c83a3fe0d3fdbb9ac18fdL203-R208) [[2]](diffhunk://#diff-340fa30a2b3021bbd3b0f5cdb034cfc14b402f806fa21344c497fc036df5cb61L99-R99)