### PR TITLE
Resolve issues with persisting client data for story list

### DIFF
--- a/docs/backend-review-2026-01-27.md
+++ b/docs/backend-review-2026-01-27.md
@@ -1,0 +1,110 @@
+# Backend Review (2026-01-27)
+
+Scope: server-side code under `src/server/*` plus server queries that expose data to the UI.
+
+Below are gaps/weaknesses or areas that are verbose/unclear, with proposed fixes.
+
+---
+
+## Reliability + Data Integrity
+
+1. **Overlapping refresh jobs / unhandled failures**
+   - **Where**: `src/server/server.ts`
+   - **Issue**: `setInterval(updateData, ...)` triggers without awaiting prior runs. If `updateData` takes >10 min or throws, the next tick overlaps. Also unhandled rejections can terminate the process depending on Node settings.
+   - **Fix**: Guard with a mutex (`isUpdating`) and wrap `updateData` in a try/catch that logs and continues. Consider `setTimeout` loop to schedule the next run after completion.
+
+2. **Refresh cadence tied to an in-memory counter**
+   - **Where**: `src/server/server.ts`
+   - **Issue**: `index` resets on restart, so day/week/month updates are dependent on uptime, not real time. That can mean missing or extra refreshes after restarts.
+   - **Fix**: Store last-refresh timestamps in DB (or in-memory + persisted) and compare against `Date.now()` to decide when to refresh each bucket.
+
+3. **File-backed DB writes are non-atomic and blocking**
+   - **Where**: `src/server/database.ts`
+   - **Issue**: `fs.writeFileSync` blocks the event loop and writes directly to the target path. A crash mid-write can leave a corrupted JSON file.
+   - **Fix**: Write to a temp file then `rename` (atomic on same volume). Switch to async `fs.promises` with try/catch and log errors.
+
+4. **DB reload has no corruption handling**
+   - **Where**: `src/server/database.ts`
+   - **Issue**: `JSON.parse` on the DB file can throw; no recovery path or backup.
+   - **Fix**: Wrap in try/catch. On parse error, keep an empty DB, write a `.bad` backup, and log a clear warning.
+
+5. **Old-story cleanup returns an inaccurate removed count**
+   - **Where**: `src/server/database.ts` (`db_clearOldStories`)
+   - **Issue**: Return value is `allIds.length - idsToKeep.length`, which is wrong if `idsToKeep` contains IDs not in `db` or duplicates.
+   - **Fix**: Track `removed` while deleting and return that count.
+
+6. **No validation on server ingest**
+   - **Where**: `src/server/getFullDataForIds.ts`, `src/server/database.ts`
+   - **Issue**: HN/Algolia responses are stored without schema validation. The UI does validate before local storage, but the server cache can accept malformed items.
+   - **Fix**: Reuse `validateHnItemWithComments` on server (or a lighter schema for cached items). Reject or sanitize invalid fields before caching.
+
+---
+
+## Performance + Scalability
+
+7. **Sequential fetch for item lists**
+   - **Where**: `src/server/api.ts` (`fetchItems`)
+   - **Issue**: Items are fetched one-by-one, which is slow and increases update latency.
+   - **Fix**: Fetch in parallel with a concurrency limit (e.g., `p-limit`) to balance speed and API load.
+
+8. **Recursive comment expansion can explode**
+   - **Where**: `src/server/database.ts` (`addAllChildren`, `addChildrenToItemRecurse`)
+   - **Issue**: Recursively loading every descendant can blow memory/time for large threads and lacks a max depth/item cap.
+   - **Fix**: Add configurable max depth and/or max total comments. Consider lazy loading deeper threads on-demand.
+
+9. **No timeout/abort on external fetches**
+   - **Where**: `src/server/api.ts`, `src/server/algolia.ts`
+   - **Issue**: Long-hanging requests can stall updates and pile up overlapping runs.
+   - **Fix**: Use `AbortController` with a timeout (e.g., 5–10s) and retry with backoff for transient failures.
+
+---
+
+## Clarity + Verbosity
+
+10. **Duplicated Algolia queries**
+    - **Where**: `src/server/algolia.ts` (`getDay`, `getWeek`, `getMonth`)
+    - **Issue**: Three near-identical functions differ only by time window.
+    - **Fix**: Implement a single helper (e.g., `getSince(secondsAgo)`) and delegate to it; keep named wrappers for readability if desired.
+
+11. **`fetch` wrapper is over-verbose**
+    - **Where**: `src/server/api.ts` (`fetch`)
+    - **Issue**: Manually wraps a Promise around `get(...)` and uses `any` types.
+    - **Fix**: Convert to `async fetch<T>()` with `try/catch` and typed return. Keep a single error path and log context.
+
+12. **Cache warmup stores stale/null data**
+    - **Where**: `src/server/server.ts` (`populateCacheFromDatabase`)
+    - **Issue**: `getItemFromDb` can return null for stale items, but nulls are cached. That makes downstream results inconsistent.
+    - **Fix**: Filter nulls before setting `cachedData[type]`.
+
+13. **Staleness calculation can divide by zero**
+    - **Where**: `src/server/database.ts` (`_isTimePastThreshold`)
+    - **Issue**: Uses `itemExt.time!` and divides by `(lastUpdated - time)`. If `time` is missing or equals `lastUpdated`, result is invalid.
+    - **Fix**: Guard `time` presence and non-zero delta; fall back to a simple max-age threshold.
+
+---
+
+## Observability + Testing
+
+14. **No structured logging**
+    - **Where**: `src/server/server.ts`, `src/server/api.ts`, `src/server/database.ts`
+    - **Issue**: `console.log` with stringy output makes it hard to correlate update cycles or failures.
+    - **Fix**: Log structured objects and include `storyType`, `durationMs`, and `error` fields. A lightweight logger (pino) can help.
+
+15. **Missing server tests**
+    - **Where**: `src/server/*`
+    - **Issue**: No tests cover update cadence, DB cache/staleness, or error handling.
+    - **Fix**: Add focused unit tests for:
+      - `_isTimePastThreshold` edge cases
+      - `db_clearOldStories` removal count
+      - `getFullDataForIds` behavior with missing items
+      - `getTopStories` validation error on unknown type
+
+---
+
+## Suggested Next Steps (small, high-impact)
+
+1. Add a guarded update loop and error handling in `src/server/server.ts`.
+2. Make DB writes atomic + async in `src/server/database.ts`.
+3. Add a concurrency-limited fetch in `src/server/api.ts`.
+4. Add a max depth limit for comment expansion.
+5. Add minimal unit tests for the data layer.

--- a/src/contexts/AppDataContext.tsx
+++ b/src/contexts/AppDataContext.tsx
@@ -156,9 +156,9 @@ export function updateStoryListDataStores(
   const p = page as StoryPage;
   const latest = data.latest;
   const d = latest?.result;
-  if (latest?.startedFromServer && d && Array.isArray(d)) {
-    console.log("*** persisting story list", p, d.length);
-    void dataStore.persistStoryList(p, d);
+
+  if (latest?.startedFromServer && d?.type === "fullData") {
+    void dataStore.persistStoryList(p, d?.data ?? []);
   }
 
   dataStore.setRefreshType({

--- a/src/features/storyList/ServerStoryList.tsx
+++ b/src/features/storyList/ServerStoryList.tsx
@@ -1,26 +1,21 @@
-import { createAsync } from "@solidjs/router";
-import { createEffect, createMemo, untrack } from "solid-js";
-import { createStore, reconcile } from "solid-js/store";
+import { createEffect, createResource, untrack } from "solid-js";
 
 import {
   updateStoryListDataStores,
   useAppData,
   useDataStore,
 } from "~/contexts/AppDataContext";
-import { mapStoriesToSummaries } from "~/lib/getSummaryViaFetch";
 import { TopStoriesType } from "~/models/interfaces";
 import { getStoryListByType } from "~/server/queries";
 
 import { HnStoryListBody } from "./HnStoryListBody";
 import { HnStoryListToggle } from "./HnStoryListToggle";
 
-import type { HnStorySummary } from "~/models/interfaces";
-
 export function ServerStoryList(props: { page: TopStoriesType }) {
   const isClientMounted = useAppData().isClientMounted;
   const dataStore = useDataStore();
 
-  const data = createAsync(async () => {
+  const [data] = createResource(async () => {
     const isClient = untrack(() => isClientMounted());
 
     if (isClient) {
@@ -29,28 +24,7 @@ export function ServerStoryList(props: { page: TopStoriesType }) {
       return { result: list, startedFromServer: false };
     }
 
-    return getStoryListByType(props.page);
-  });
-
-  const summaries = createMemo(() => {
-    const fromQuery = data.latest?.result;
-    if (fromQuery && fromQuery.type === "fullData") {
-      // we need to map the full data to summaries
-      return mapStoriesToSummaries(fromQuery.data);
-    }
-    return fromQuery?.data;
-  });
-
-  const [summaryStore, setSummaryStore] = createStore<HnStorySummary[]>(
-    data.latest?.result?.data ?? []
-  );
-
-  createEffect(() => {
-    const sums = summaries();
-    if (sums) {
-      // in theory this store should give a nice reorder effect for auto-animate?
-      setSummaryStore(reconcile(sums, { key: "id" }));
-    }
+    return await getStoryListByType(props.page);
   });
 
   createEffect(() => {
@@ -59,7 +33,7 @@ export function ServerStoryList(props: { page: TopStoriesType }) {
 
   return (
     <>
-      <HnStoryListBody items={summaryStore} page={props.page} />
+      <HnStoryListBody items={data()?.result?.data ?? []} page={props.page} />
       <HnStoryListToggle />
     </>
   );


### PR DESCRIPTION
This pull request focuses on improving the reliability, clarity, and maintainability of the server-side story list fetching and caching logic. The main changes include simplifying the `ServerStoryList` component by removing unnecessary state management, updating how story lists are persisted, and documenting backend weaknesses and proposed fixes for future improvements.

Key changes:

### Codebase Simplification & Refactoring

* Refactored `ServerStoryList` in `src/features/storyList/ServerStoryList.tsx` to use `createResource` instead of `createAsync`, and removed the local store and memoization logic for story summaries, directly passing the fetched data to the UI. This reduces complexity and potential sources of bugs. [[1]](diffhunk://#diff-f6c63a379ebcba2bf8db05b2c0cb91b71da75bbd52141fe795d372ff571cfb0eL1-R18) [[2]](diffhunk://#diff-f6c63a379ebcba2bf8db05b2c0cb91b71da75bbd52141fe795d372ff571cfb0eL32-R27) [[3]](diffhunk://#diff-f6c63a379ebcba2bf8db05b2c0cb91b71da75bbd52141fe795d372ff571cfb0eL62-R36)
* Updated the logic in `updateStoryListDataStores` (`src/contexts/AppDataContext.tsx`) to persist story lists only when the fetched data is of type `"fullData"`, ensuring that only valid, complete data is stored.

### Documentation & Review

* Added a comprehensive backend review document (`docs/backend-review-2026-01-27.md`) outlining current weaknesses in reliability, data integrity, performance, clarity, observability, and testing of the server-side code, along with proposed fixes and prioritized next steps for future work.